### PR TITLE
feat: 导出时自动裁剪透明区域

### DIFF
--- a/src/components/UploadDialog.tsx
+++ b/src/components/UploadDialog.tsx
@@ -18,6 +18,7 @@ import {
 import { Close, ContentCopy, CloudUpload } from '@mui/icons-material'
 import { useState, useEffect } from 'react'
 import GallerySubmitForm from './GallerySubmitForm'
+import { cropCanvasToContent } from '../utils/cropCanvas'
 
 interface UploadDialogProps {
   open: boolean
@@ -52,9 +53,10 @@ function UploadDialog({ open, onClose, canvas, altText = '', onUploadSuccess, ch
     setUploadProgress(0)
 
     try {
-      // 将 canvas 转换为 Blob
+      // 导出前按内容边界裁剪，避免非 1:1 自定义图带上透明填充
+      const exportCanvas = cropCanvasToContent(canvas)
       const blob = await new Promise<Blob | null>((resolve) => {
-        canvas.toBlob(resolve, 'image/png')
+        exportCanvas.toBlob(resolve, 'image/png')
       })
 
       if (!blob) {

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -3,6 +3,7 @@
 
 import { useCallback, RefObject } from 'react'
 import { b64toBlob } from '../utils/imageConversion'
+import { canvasWithWhiteBackground, cropCanvasToContent } from '../utils/cropCanvas'
 import characters from '../characters.json'
 import { Character, ExportHooks } from '../types'
 
@@ -10,7 +11,9 @@ const { ClipboardItem } = window
 const typedCharacters = characters as Character[]
 
 /**
- * Hook that handles all export/download/copy operations
+ * Hook that handles all export/download/copy operations.
+ * Exports are auto-cropped to non-transparent content so custom non-1:1
+ * images do not keep empty transparent padding from the fixed canvas.
  */
 export function useExport(
   canvasRef: RefObject<HTMLCanvasElement>,
@@ -37,79 +40,68 @@ export function useExport(
     [character, text, customImage]
   )
 
-  const download = useCallback(async (): Promise<void> => {
+  /** Preview canvas stays 296×256; export uses content bounds only. */
+  const getExportCanvas = useCallback((): HTMLCanvasElement | null => {
     const canvas = canvasRef.current
-    if (!canvas) return
+    if (!canvas) return null
+    return cropCanvasToContent(canvas)
+  }, [canvasRef])
+
+  const download = useCallback(async (): Promise<void> => {
+    const exportCanvas = getExportCanvas()
+    if (!exportCanvas) return
     const link = document.createElement('a')
     link.download = generateFileName('png')
-    link.href = canvas.toDataURL('image/png')
+    link.href = exportCanvas.toDataURL('image/png')
     link.click()
     setDownloadPopupOpen(true)
-  }, [canvasRef, generateFileName, setDownloadPopupOpen])
+  }, [getExportCanvas, generateFileName, setDownloadPopupOpen])
 
   const downloadWebp = useCallback(async (): Promise<void> => {
-    const canvas = canvasRef.current
-    if (!canvas) return
+    const exportCanvas = getExportCanvas()
+    if (!exportCanvas) return
     const link = document.createElement('a')
     link.download = generateFileName('webp')
-    link.href = canvas.toDataURL('image/webp')
+    link.href = exportCanvas.toDataURL('image/webp')
     link.click()
     setDownloadPopupOpen(true)
-  }, [canvasRef, generateFileName, setDownloadPopupOpen])
+  }, [getExportCanvas, generateFileName, setDownloadPopupOpen])
 
   const downloadJpg = useCallback(async (): Promise<void> => {
-    const canvas = canvasRef.current
-    if (!canvas) return
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
-    const data = ctx.getImageData(0, 0, canvas.width, canvas.height)
-    const compositeOperation = ctx.globalCompositeOperation
-    ctx.globalCompositeOperation = 'destination-over'
-    ctx.fillStyle = 'white'
-    ctx.fillRect(0, 0, canvas.width, canvas.height)
-    const imageData = canvas.toDataURL('image/jpeg')
-    ctx.clearRect(0, 0, canvas.width, canvas.height)
-    ctx.putImageData(data, 0, 0)
-    ctx.globalCompositeOperation = compositeOperation
+    const exportCanvas = getExportCanvas()
+    if (!exportCanvas) return
+    const withBg = canvasWithWhiteBackground(exportCanvas)
     const link = document.createElement('a')
     link.download = generateFileName('jpg')
-    link.href = imageData
+    link.href = withBg.toDataURL('image/jpeg')
     link.click()
     setDownloadPopupOpen(true)
-  }, [canvasRef, generateFileName, setDownloadPopupOpen])
+  }, [getExportCanvas, generateFileName, setDownloadPopupOpen])
 
   const copy = useCallback(async (): Promise<void> => {
-    const canvas = canvasRef.current
-    if (!canvas) return
+    const exportCanvas = getExportCanvas()
+    if (!exportCanvas) return
     await navigator.clipboard.write([
       new ClipboardItem({
-        'image/png': b64toBlob(canvas.toDataURL().split(',')[1]),
+        'image/png': b64toBlob(exportCanvas.toDataURL().split(',')[1]),
       }),
     ])
     setCopyPopupOpen(true)
-  }, [canvasRef, setCopyPopupOpen])
+  }, [getExportCanvas, setCopyPopupOpen])
 
   const copyWithBg = useCallback(async (): Promise<void> => {
-    const canvas = canvasRef.current
-    if (!canvas) return
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
-    const data = ctx.getImageData(0, 0, canvas.width, canvas.height)
-    const compositeOperation = ctx.globalCompositeOperation
-    ctx.globalCompositeOperation = 'destination-over'
-    ctx.fillStyle = 'white'
-    ctx.fillRect(0, 0, canvas.width, canvas.height)
-    const imageData = canvas.toDataURL('image/jpeg')
-    ctx.clearRect(0, 0, canvas.width, canvas.height)
-    ctx.putImageData(data, 0, 0)
-    ctx.globalCompositeOperation = compositeOperation
+    const exportCanvas = getExportCanvas()
+    if (!exportCanvas) return
+    const withBg = canvasWithWhiteBackground(exportCanvas)
+    // Clipboard paste for JPEG path still uses PNG container for broader support,
+    // with opaque white background baked in.
     await navigator.clipboard.write([
       new ClipboardItem({
-        'image/png': b64toBlob(imageData.split(',')[1]),
+        'image/png': b64toBlob(withBg.toDataURL('image/png').split(',')[1]),
       }),
     ])
     setCopyPopupOpen(true)
-  }, [canvasRef, setCopyPopupOpen])
+  }, [getExportCanvas, setCopyPopupOpen])
 
   return {
     download,

--- a/src/utils/cropCanvas.ts
+++ b/src/utils/cropCanvas.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 The 25-ji-code-de Team
+
+export interface ContentBounds {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/**
+ * Find the bounding box of non-transparent pixels on a canvas.
+ * Returns null when the canvas is fully transparent.
+ */
+export function getContentBounds(
+  canvas: HTMLCanvasElement,
+  alphaThreshold: number = 0
+): ContentBounds | null {
+  // Do not pass contextAttributes here: the preview canvas already has a 2d
+  // context; re-requesting with different attributes can return null.
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return null
+
+  const { width, height } = canvas
+  if (width === 0 || height === 0) return null
+
+  const { data } = ctx.getImageData(0, 0, width, height)
+
+  let minX = width
+  let minY = height
+  let maxX = -1
+  let maxY = -1
+
+  for (let y = 0; y < height; y++) {
+    const row = y * width * 4
+    for (let x = 0; x < width; x++) {
+      if (data[row + x * 4 + 3] > alphaThreshold) {
+        if (x < minX) minX = x
+        if (x > maxX) maxX = x
+        if (y < minY) minY = y
+        if (y > maxY) maxY = y
+      }
+    }
+  }
+
+  if (maxX < minX || maxY < minY) return null
+
+  return {
+    x: minX,
+    y: minY,
+    width: maxX - minX + 1,
+    height: maxY - minY + 1,
+  }
+}
+
+/**
+ * Create a new canvas cropped to non-transparent content.
+ * Falls back to a full copy when content fills the canvas or is empty.
+ */
+export function cropCanvasToContent(
+  source: HTMLCanvasElement,
+  alphaThreshold: number = 0
+): HTMLCanvasElement {
+  const bounds = getContentBounds(source, alphaThreshold)
+  const cropped = document.createElement('canvas')
+
+  if (!bounds || (bounds.width === source.width && bounds.height === source.height)) {
+    cropped.width = source.width
+    cropped.height = source.height
+    const ctx = cropped.getContext('2d')
+    if (ctx) ctx.drawImage(source, 0, 0)
+    return cropped
+  }
+
+  cropped.width = bounds.width
+  cropped.height = bounds.height
+  const ctx = cropped.getContext('2d')
+  if (ctx) {
+    ctx.drawImage(
+      source,
+      bounds.x,
+      bounds.y,
+      bounds.width,
+      bounds.height,
+      0,
+      0,
+      bounds.width,
+      bounds.height
+    )
+  }
+  return cropped
+}
+
+/**
+ * Draw source onto a new canvas with an opaque white background.
+ * Useful for JPEG export / clipboard with white fill.
+ */
+export function canvasWithWhiteBackground(source: HTMLCanvasElement): HTMLCanvasElement {
+  const out = document.createElement('canvas')
+  out.width = source.width
+  out.height = source.height
+  const ctx = out.getContext('2d')
+  if (ctx) {
+    ctx.fillStyle = 'white'
+    ctx.fillRect(0, 0, out.width, out.height)
+    ctx.drawImage(source, 0, 0)
+  }
+  return out
+}


### PR DESCRIPTION
## Summary
- 自定义非 1:1 图片在固定 296×256 画布上 contain 居中绘制后，空余区域为透明
- 导出（复制 PNG/JPG、保存 PNG/JPG/WEBP、上传分享）时按非透明像素边界自动裁剪
- 预览画布保持不变，仅影响导出结果；JPG 路径仍白底填充

## 实现
- 新增 `src/utils/cropCanvas.ts`：`getContentBounds` / `cropCanvasToContent` / `canvasWithWhiteBackground`
- `useExport` 所有导出路径统一走裁剪画布，且不再改动预览 canvas（JPG 也不再 in-place 改主画布）
- `UploadDialog` 上传 PNG 前同样裁剪

## Test plan
- [x] 上传竖图/横图自定义角色，预览仍为 296×256 contain 居中
- [x] 保存 PNG：尺寸应为内容边界，无多余透明边
- [ ] 保存 WEBP：同上
- [ ] 保存 JPG：裁剪后白底，无大块透明转白边
- [ ] 复制 PNG / 复制 JPG：剪贴板内容与下载一致
- [ ] 上传分享：上传图同样被裁剪
- [x] 使用内置 1:1 角色图导出：尺寸与原先一致（已铺满则不裁）

Closes #5