### PR TITLE
feat: 导出设置（尺寸倍率 / 质量 / 压缩）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,14 +29,14 @@ import {
   HelpOutline,
   Explore,
 } from '@mui/icons-material'
-import { useCallback, useEffect, useRef, lazy, Suspense } from 'react'
+import { useCallback, useEffect, useRef, useState, lazy, Suspense } from 'react'
 import characters from './characters.json'
 import Canvas from './components/Canvas'
 import Picker from './components/Picker'
 import ThemeWrapper from './components/ThemeWrapper'
 import NotificationSnackbar from './components/controls/NotificationSnackbar'
 import TextStylePanel from './components/sections/TextStylePanel'
-import ExportPanel from './components/sections/ExportPanel'
+import ExportPanel, { ExportScale } from './components/sections/ExportPanel'
 import LoginButton from './components/auth/LoginButton'
 import UserMenu from './components/auth/UserMenu'
 
@@ -93,13 +93,23 @@ function App() {
   const stroke = useStroke()
   const canvasDrawing = useCanvasDrawing()
 
+  // Export settings (scale / quality / compress) — default matches previous behaviour
+  const [exportScale, setExportScale] = useState<ExportScale>(1)
+  const [exportQuality, setExportQuality] = useState(92)
+  const [exportCompress, setExportCompress] = useState(true)
+
   const exportHooks = useExport(
     canvasRef,
     characterHook.character,
     characterHook.customImage,
     textSettings.text,
     uiState.setCopyPopupOpen,
-    uiState.setDownloadPopupOpen
+    uiState.setDownloadPopupOpen,
+    {
+      scale: exportScale,
+      quality: exportQuality / 100,
+      compress: exportCompress,
+    }
   )
 
   const history = useHistory()
@@ -695,6 +705,12 @@ function App() {
                 onDownloadJpg={handleDownloadJpg}
                 onDownloadWebp={handleDownloadWebp}
                 onUpload={() => uiState.setUploadOpen(true)}
+                scale={exportScale}
+                onScaleChange={setExportScale}
+                quality={exportQuality}
+                onQualityChange={setExportQuality}
+                compress={exportCompress}
+                onCompressChange={setExportCompress}
               />
             </Box>
           </Grid>
@@ -806,6 +822,12 @@ function App() {
               onDownloadJpg={handleDownloadJpg}
               onDownloadWebp={handleDownloadWebp}
               onUpload={() => uiState.setUploadOpen(true)}
+              scale={exportScale}
+              onScaleChange={setExportScale}
+              quality={exportQuality}
+              onQualityChange={setExportQuality}
+              compress={exportCompress}
+              onCompressChange={setExportCompress}
             />
           </Grid>
         </Grid>
@@ -945,6 +967,7 @@ function App() {
           onUploadSuccess={(url) => saveToHistory(url)}
           characterId={characterHook.character}
           customImage={characterHook.customImage}
+          exportScale={exportScale}
         />
       </Suspense>
 

--- a/src/components/UploadDialog.tsx
+++ b/src/components/UploadDialog.tsx
@@ -18,7 +18,7 @@ import {
 import { Close, ContentCopy, CloudUpload } from '@mui/icons-material'
 import { useState, useEffect } from 'react'
 import GallerySubmitForm from './GallerySubmitForm'
-import { cropCanvasToContent } from '../utils/cropCanvas'
+import { prepareExportCanvas } from '../utils/cropCanvas'
 
 interface UploadDialogProps {
   open: boolean
@@ -28,9 +28,20 @@ interface UploadDialogProps {
   onUploadSuccess?: (url: string) => void
   characterId?: number
   customImage?: string | null
+  /** Export scale multiplier (1 / 2 / 3), same as export panel */
+  exportScale?: number
 }
 
-function UploadDialog({ open, onClose, canvas, altText = '', onUploadSuccess, characterId, customImage }: UploadDialogProps) {
+function UploadDialog({
+  open,
+  onClose,
+  canvas,
+  altText = '',
+  onUploadSuccess,
+  characterId,
+  customImage,
+  exportScale = 1,
+}: UploadDialogProps) {
   const [uploading, setUploading] = useState(false)
   const [uploadProgress, setUploadProgress] = useState(0)
   const [uploadedUrl, setUploadedUrl] = useState('')
@@ -53,8 +64,8 @@ function UploadDialog({ open, onClose, canvas, altText = '', onUploadSuccess, ch
     setUploadProgress(0)
 
     try {
-      // 导出前按内容边界裁剪，避免非 1:1 自定义图带上透明填充
-      const exportCanvas = cropCanvasToContent(canvas)
+      // 裁剪透明边 + 按导出倍率缩放（与导出面板一致）
+      const exportCanvas = prepareExportCanvas(canvas, exportScale)
       const blob = await new Promise<Blob | null>((resolve) => {
         exportCanvas.toBlob(resolve, 'image/png')
       })

--- a/src/components/sections/ExportPanel.tsx
+++ b/src/components/sections/ExportPanel.tsx
@@ -1,8 +1,22 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 The 25-ji-code-de Team
 
-import { Grid, Button, Typography, Paper } from '@mui/material'
+import {
+  Grid,
+  Button,
+  Typography,
+  Paper,
+  Box,
+  ToggleButton,
+  ToggleButtonGroup,
+  FormControlLabel,
+  Switch,
+  Slider,
+  Divider,
+} from '@mui/material'
 import { ContentCopyTwoTone, DownloadTwoTone, CloudUpload } from '@mui/icons-material'
+
+export type ExportScale = 1 | 2 | 3
 
 interface ExportPanelProps {
   onCopy: () => void
@@ -11,10 +25,17 @@ interface ExportPanelProps {
   onDownloadJpg: () => void
   onDownloadWebp: () => void
   onUpload: () => void
+  scale: ExportScale
+  onScaleChange: (scale: ExportScale) => void
+  quality: number
+  onQualityChange: (quality: number) => void
+  compress: boolean
+  onCompressChange: (compress: boolean) => void
 }
 
 /**
- * Panel that groups all export buttons
+ * Panel that groups all export buttons and export settings
+ * (scale / quality / compression).
  */
 export default function ExportPanel({
   onCopy,
@@ -23,6 +44,12 @@ export default function ExportPanel({
   onDownloadJpg,
   onDownloadWebp,
   onUpload,
+  scale,
+  onScaleChange,
+  quality,
+  onQualityChange,
+  compress,
+  onCompressChange,
 }: ExportPanelProps) {
   return (
     <Paper elevation={3} sx={{ p: 2 }}>
@@ -97,6 +124,65 @@ export default function ExportPanel({
           </Button>
         </Grid>
       </Grid>
+
+      <Divider sx={{ my: 2 }} />
+
+      <Typography variant="subtitle1" gutterBottom>
+        导出设置
+      </Typography>
+
+      <Box sx={{ mb: 1.5 }}>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          导出尺寸
+        </Typography>
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          color="secondary"
+          value={scale}
+          onChange={(_, value: ExportScale | null) => {
+            if (value != null) onScaleChange(value)
+          }}
+          fullWidth
+        >
+          <ToggleButton value={1}>1×</ToggleButton>
+          <ToggleButton value={2}>2×</ToggleButton>
+          <ToggleButton value={3}>3×</ToggleButton>
+        </ToggleButtonGroup>
+        <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
+          基于当前预览内容放大导出；不会提升底图本身的清晰度
+        </Typography>
+      </Box>
+
+      <FormControlLabel
+        control={
+          <Switch
+            checked={compress}
+            onChange={(_, checked) => onCompressChange(checked)}
+            color="secondary"
+          />
+        }
+        label="压缩（JPG / WEBP）"
+      />
+
+      <Box sx={{ mt: 0.5, opacity: compress ? 1 : 0.45, pointerEvents: compress ? 'auto' : 'none' }}>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          压缩质量：{quality}%
+        </Typography>
+        <Slider
+          value={quality}
+          onChange={(_, v) => onQualityChange(Array.isArray(v) ? v[0] : v)}
+          min={10}
+          max={100}
+          step={1}
+          color="secondary"
+          valueLabelDisplay="auto"
+          valueLabelFormat={(v) => `${v}%`}
+        />
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+          仅影响 JPG / WEBP；PNG 始终无损。关闭压缩时有损格式使用最高质量。
+        </Typography>
+      </Box>
     </Paper>
   )
 }

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -3,17 +3,31 @@
 
 import { useCallback, RefObject } from 'react'
 import { b64toBlob } from '../utils/imageConversion'
-import { canvasWithWhiteBackground, cropCanvasToContent } from '../utils/cropCanvas'
+import {
+  canvasWithWhiteBackground,
+  prepareExportCanvas,
+} from '../utils/cropCanvas'
 import characters from '../characters.json'
 import { Character, ExportHooks } from '../types'
 
 const { ClipboardItem } = window
 const typedCharacters = characters as Character[]
 
+export interface ExportSettings {
+  /** Export pixel scale relative to the cropped preview canvas (1 / 2 / 3). */
+  scale: number
+  /**
+   * Lossy quality 0–1 for JPG / WEBP.
+   * PNG exports ignore this (always lossless).
+   */
+  quality: number
+  /** When false, lossy formats use quality 1 (maximum). */
+  compress: boolean
+}
+
 /**
  * Hook that handles all export/download/copy operations.
- * Exports are auto-cropped to non-transparent content so custom non-1:1
- * images do not keep empty transparent padding from the fixed canvas.
+ * Exports are auto-cropped to non-transparent content, then optionally scaled.
  */
 export function useExport(
   canvasRef: RefObject<HTMLCanvasElement>,
@@ -21,8 +35,11 @@ export function useExport(
   customImage: string | null,
   text: string,
   setCopyPopupOpen: (open: boolean) => void,
-  setDownloadPopupOpen: (open: boolean) => void
+  setDownloadPopupOpen: (open: boolean) => void,
+  exportSettings: ExportSettings
 ): ExportHooks {
+  const { scale, quality, compress } = exportSettings
+
   const generateFileName = useCallback(
     (ext: string): string => {
       // Remove spaces and illegal characters
@@ -40,12 +57,14 @@ export function useExport(
     [character, text, customImage]
   )
 
-  /** Preview canvas stays 296×256; export uses content bounds only. */
+  /** Preview canvas stays 296×256; export uses content bounds + scale. */
   const getExportCanvas = useCallback((): HTMLCanvasElement | null => {
     const canvas = canvasRef.current
     if (!canvas) return null
-    return cropCanvasToContent(canvas)
-  }, [canvasRef])
+    return prepareExportCanvas(canvas, scale)
+  }, [canvasRef, scale])
+
+  const lossyQuality = compress ? Math.min(1, Math.max(0.1, quality)) : 1
 
   const download = useCallback(async (): Promise<void> => {
     const exportCanvas = getExportCanvas()
@@ -62,10 +81,10 @@ export function useExport(
     if (!exportCanvas) return
     const link = document.createElement('a')
     link.download = generateFileName('webp')
-    link.href = exportCanvas.toDataURL('image/webp')
+    link.href = exportCanvas.toDataURL('image/webp', lossyQuality)
     link.click()
     setDownloadPopupOpen(true)
-  }, [getExportCanvas, generateFileName, setDownloadPopupOpen])
+  }, [getExportCanvas, generateFileName, setDownloadPopupOpen, lossyQuality])
 
   const downloadJpg = useCallback(async (): Promise<void> => {
     const exportCanvas = getExportCanvas()
@@ -73,10 +92,10 @@ export function useExport(
     const withBg = canvasWithWhiteBackground(exportCanvas)
     const link = document.createElement('a')
     link.download = generateFileName('jpg')
-    link.href = withBg.toDataURL('image/jpeg')
+    link.href = withBg.toDataURL('image/jpeg', lossyQuality)
     link.click()
     setDownloadPopupOpen(true)
-  }, [getExportCanvas, generateFileName, setDownloadPopupOpen])
+  }, [getExportCanvas, generateFileName, setDownloadPopupOpen, lossyQuality])
 
   const copy = useCallback(async (): Promise<void> => {
     const exportCanvas = getExportCanvas()
@@ -93,7 +112,7 @@ export function useExport(
     const exportCanvas = getExportCanvas()
     if (!exportCanvas) return
     const withBg = canvasWithWhiteBackground(exportCanvas)
-    // Clipboard paste for JPEG path still uses PNG container for broader support,
+    // Clipboard paste still uses PNG container for broader support,
     // with opaque white background baked in.
     await navigator.clipboard.write([
       new ClipboardItem({

--- a/src/utils/cropCanvas.ts
+++ b/src/utils/cropCanvas.ts
@@ -107,3 +107,34 @@ export function canvasWithWhiteBackground(source: HTMLCanvasElement): HTMLCanvas
   }
   return out
 }
+
+/**
+ * Scale a canvas by an integer/float factor using high-quality smoothing.
+ * scale <= 1 returns the same canvas reference (no copy) for the common 1x path.
+ */
+export function scaleCanvas(source: HTMLCanvasElement, scale: number): HTMLCanvasElement {
+  if (!Number.isFinite(scale) || scale <= 0 || scale === 1) {
+    return source
+  }
+
+  const out = document.createElement('canvas')
+  out.width = Math.max(1, Math.round(source.width * scale))
+  out.height = Math.max(1, Math.round(source.height * scale))
+  const ctx = out.getContext('2d')
+  if (ctx) {
+    ctx.imageSmoothingEnabled = true
+    ctx.imageSmoothingQuality = 'high'
+    ctx.drawImage(source, 0, 0, out.width, out.height)
+  }
+  return out
+}
+
+/**
+ * Crop transparent padding then optionally scale for export.
+ */
+export function prepareExportCanvas(
+  source: HTMLCanvasElement,
+  scale: number = 1
+): HTMLCanvasElement {
+  return scaleCanvas(cropCanvasToContent(source), scale)
+}


### PR DESCRIPTION
## Summary
- Parent: #3（底图分辨率有限，无法真正“变清晰”）
- Sub-issue: #7 — 在导出选项下方增加可选导出参数，按场景权衡尺寸与体积

## Changes
- **导出尺寸**：`1×` / `2×` / `3×`（默认 1×，预览画布不变）
- **压缩开关** + **质量滑块**（10–100%，默认 92%）：仅影响 JPG / WEBP；PNG 始终无损
- 复制 / 下载 / 上传分享均走同一套 `prepareExportCanvas`（先裁透明边再缩放）
- UI 文案明确：放大不会提升底图本身清晰度

## Test plan
- [ ] 默认 1× + 压缩开启 + 92%：行为与改前基本一致
- [ ] 选 2× / 3× 保存 PNG：尺寸约为裁剪后 1× 的 2/3 倍
- [ ] 保存 JPG / WEBP：调低质量后文件明显变小
- [ ] 关闭压缩：JPG/WEBP 使用最高质量
- [ ] 复制 PNG / 上传分享：尊重当前倍率
- [ ] 非 1:1 自定义图：裁剪 + 倍率同时生效

Closes #7