### PR TITLE
fix: 导出倍率改为离屏高清重绘而非位图放大

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,6 +98,54 @@ function App() {
   const [exportQuality, setExportQuality] = useState(92)
   const [exportCompress, setExportCompress] = useState(true)
 
+  /**
+   * Re-draw the sticker onto an offscreen canvas at `scale`× pixel density.
+   * Text/stroke are re-rasterized (sharp); character art uses full source pixels
+   * but cannot invent detail beyond the asset resolution.
+   */
+  const renderAtScale = useCallback(
+    (scale: number): HTMLCanvasElement | null => {
+      const offscreen = document.createElement('canvas')
+      const ctx = offscreen.getContext('2d')
+      if (!ctx) return null
+      canvasDrawing.draw(
+        ctx,
+        characterHook.imgObj,
+        characterHook.loaded,
+        textSettings.text,
+        position.position,
+        textSettings.rotate,
+        {
+          fontSize: textSettings.fontSize,
+          fontKey: textSettings.fontKey,
+          spaceSize: textSettings.spaceSize,
+          letterSpacing: textSettings.letterSpacing,
+          curve: textSettings.curve,
+          vertical: textSettings.vertical,
+        },
+        {
+          textColor: colorScheme.textColor,
+        },
+        {
+          strokeWidth: stroke.strokeWidth,
+          strokeColor: stroke.strokeColor,
+        },
+        textSettings.textBehind,
+        scale
+      )
+      return offscreen
+    },
+    [
+      canvasDrawing,
+      characterHook.imgObj,
+      characterHook.loaded,
+      textSettings,
+      position.position,
+      colorScheme.textColor,
+      stroke,
+    ]
+  )
+
   const exportHooks = useExport(
     canvasRef,
     characterHook.character,
@@ -109,7 +157,8 @@ function App() {
       scale: exportScale,
       quality: exportQuality / 100,
       compress: exportCompress,
-    }
+    },
+    renderAtScale
   )
 
   const history = useHistory()
@@ -968,6 +1017,7 @@ function App() {
           characterId={characterHook.character}
           customImage={characterHook.customImage}
           exportScale={exportScale}
+          renderAtScale={renderAtScale}
         />
       </Suspense>
 

--- a/src/components/UploadDialog.tsx
+++ b/src/components/UploadDialog.tsx
@@ -18,7 +18,7 @@ import {
 import { Close, ContentCopy, CloudUpload } from '@mui/icons-material'
 import { useState, useEffect } from 'react'
 import GallerySubmitForm from './GallerySubmitForm'
-import { prepareExportCanvas } from '../utils/cropCanvas'
+import { cropCanvasToContent } from '../utils/cropCanvas'
 
 interface UploadDialogProps {
   open: boolean
@@ -30,6 +30,11 @@ interface UploadDialogProps {
   customImage?: string | null
   /** Export scale multiplier (1 / 2 / 3), same as export panel */
   exportScale?: number
+  /**
+   * Hi-DPI re-render (text stays sharp). Falls back to preview canvas + crop
+   * when not provided.
+   */
+  renderAtScale?: (scale: number) => HTMLCanvasElement | null
 }
 
 function UploadDialog({
@@ -41,6 +46,7 @@ function UploadDialog({
   characterId,
   customImage,
   exportScale = 1,
+  renderAtScale,
 }: UploadDialogProps) {
   const [uploading, setUploading] = useState(false)
   const [uploadProgress, setUploadProgress] = useState(0)
@@ -57,15 +63,17 @@ function UploadDialog({
   }, [open])
 
   const uploadToStorage = async () => {
-    if (!canvas) return
-
     setUploading(true)
     setError('')
     setUploadProgress(0)
 
     try {
-      // 裁剪透明边 + 按导出倍率缩放（与导出面板一致）
-      const exportCanvas = prepareExportCanvas(canvas, exportScale)
+      // 按倍率离屏重绘（文字清晰）再裁透明边；失败则回退预览画布
+      const rendered = renderAtScale?.(exportScale) ?? canvas
+      if (!rendered) {
+        throw new Error('无法生成图片')
+      }
+      const exportCanvas = cropCanvasToContent(rendered)
       const blob = await new Promise<Blob | null>((resolve) => {
         exportCanvas.toBlob(resolve, 'image/png')
       })

--- a/src/components/sections/ExportPanel.tsx
+++ b/src/components/sections/ExportPanel.tsx
@@ -150,7 +150,7 @@ export default function ExportPanel({
           <ToggleButton value={3}>3×</ToggleButton>
         </ToggleButtonGroup>
         <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
-          基于当前预览内容放大导出；不会提升底图本身的清晰度
+          按倍率重新绘制导出（文字/描边更清晰）；角色底图仍受素材分辨率限制
         </Typography>
       </Box>
 

--- a/src/hooks/useCanvasDrawing.ts
+++ b/src/hooks/useCanvasDrawing.ts
@@ -11,6 +11,13 @@ const FONT_STACKS: Record<FontKey, string> = {
     "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
 }
 
+/** Logical (CSS) size of the sticker canvas at 1× */
+export const CANVAS_WIDTH = 296
+export const CANVAS_HEIGHT = 256
+
+/** Magic offset used in vertical line step: fontSize + spaceSize - VERTICAL_LINE_GAP */
+const VERTICAL_LINE_GAP = 40
+
 interface TextSettings {
   fontSize: number
   fontKey: FontKey
@@ -30,7 +37,9 @@ interface Stroke {
 }
 
 /**
- * Hook that encapsulates all canvas drawing logic
+ * Hook that encapsulates all canvas drawing logic.
+ * Pass `scale` > 1 for high-DPI export: layout is multiplied so text/strokes
+ * are re-rasterized at higher resolution instead of upscaling a bitmap.
  */
 export function useCanvasDrawing() {
   const drawText = useCallback(
@@ -42,7 +51,9 @@ export function useCanvasDrawing() {
       textSettings: TextSettings,
       colors: Colors,
       stroke: Stroke,
-      angle: number
+      angle: number,
+      /** Scale factor applied to the fixed vertical line-gap constant */
+      scale: number = 1
     ): void => {
       const { fontSize, fontKey, spaceSize, letterSpacing, curve, vertical } = textSettings
       const { textColor } = colors
@@ -72,7 +83,7 @@ export function useCanvasDrawing() {
         }
       } else if (vertical) {
         const letterStep = fontSize + letterSpacing
-        const lineStep = fontSize + spaceSize - 40
+        const lineStep = fontSize + spaceSize - VERTICAL_LINE_GAP * scale
         let xOffset = 0
         for (const line of lines) {
           let yOffset = 0
@@ -123,10 +134,16 @@ export function useCanvasDrawing() {
       textSettings: TextSettings,
       colors: Colors,
       stroke: Stroke,
-      textBehind: boolean
+      textBehind: boolean,
+      /**
+       * Pixel scale for export (1 = preview size).
+       * Text / stroke / positions are re-drawn at this density — not bitmap-upscaled.
+       */
+      scale: number = 1
     ): void => {
-      const w = 296
-      const h = 256
+      const s = Number.isFinite(scale) && scale > 0 ? scale : 1
+      const w = Math.round(CANVAS_WIDTH * s)
+      const h = Math.round(CANVAS_HEIGHT * s)
       if (ctx.canvas.width !== w) ctx.canvas.width = w
       if (ctx.canvas.height !== h) ctx.canvas.height = h
 
@@ -143,10 +160,37 @@ export function useCanvasDrawing() {
 
         const angle = (Math.PI * text.length) / 7
 
-        if (textBehind) {
-          drawText(ctx, text, position, rotate, textSettings, colors, stroke, angle)
+        // Scale layout so geometry matches 1× preview, at higher pixel density
+        const scaledPosition = { x: position.x * s, y: position.y * s }
+        const scaledTextSettings: TextSettings = {
+          ...textSettings,
+          fontSize: textSettings.fontSize * s,
+          spaceSize: textSettings.spaceSize * s,
+          letterSpacing: textSettings.letterSpacing * s,
+        }
+        const scaledStroke: Stroke = {
+          strokeWidth: stroke.strokeWidth * s,
+          strokeColor: stroke.strokeColor,
         }
 
+        if (textBehind) {
+          drawText(
+            ctx,
+            text,
+            scaledPosition,
+            rotate,
+            scaledTextSettings,
+            colors,
+            scaledStroke,
+            angle,
+            s
+          )
+        }
+
+        // drawImage uses full source pixels; if the asset is low-res it still
+        // cannot invent detail, but text below is re-rasterized sharply.
+        ctx.imageSmoothingEnabled = true
+        ctx.imageSmoothingQuality = 'high'
         ctx.drawImage(
           img,
           0,
@@ -160,7 +204,17 @@ export function useCanvasDrawing() {
         )
 
         if (!textBehind) {
-          drawText(ctx, text, position, rotate, textSettings, colors, stroke, angle)
+          drawText(
+            ctx,
+            text,
+            scaledPosition,
+            rotate,
+            scaledTextSettings,
+            colors,
+            scaledStroke,
+            angle,
+            s
+          )
         }
       } else {
         // 空状态 - 显示渐变背景

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -5,7 +5,7 @@ import { useCallback, RefObject } from 'react'
 import { b64toBlob } from '../utils/imageConversion'
 import {
   canvasWithWhiteBackground,
-  prepareExportCanvas,
+  cropCanvasToContent,
 } from '../utils/cropCanvas'
 import characters from '../characters.json'
 import { Character, ExportHooks } from '../types'
@@ -14,7 +14,11 @@ const { ClipboardItem } = window
 const typedCharacters = characters as Character[]
 
 export interface ExportSettings {
-  /** Export pixel scale relative to the cropped preview canvas (1 / 2 / 3). */
+  /**
+   * Export pixel scale (1 / 2 / 3).
+   * Re-renders the sticker at this density (text stays sharp);
+   * does not invent detail for low-res character art.
+   */
   scale: number
   /**
    * Lossy quality 0–1 for JPG / WEBP.
@@ -26,8 +30,14 @@ export interface ExportSettings {
 }
 
 /**
+ * Renders the current sticker onto a canvas at the given scale.
+ * Used for hi-DPI export instead of bitmap-upscaling the preview.
+ */
+export type RenderAtScale = (scale: number) => HTMLCanvasElement | null
+
+/**
  * Hook that handles all export/download/copy operations.
- * Exports are auto-cropped to non-transparent content, then optionally scaled.
+ * Exports are re-drawn at the chosen scale, then auto-cropped.
  */
 export function useExport(
   canvasRef: RefObject<HTMLCanvasElement>,
@@ -36,7 +46,8 @@ export function useExport(
   text: string,
   setCopyPopupOpen: (open: boolean) => void,
   setDownloadPopupOpen: (open: boolean) => void,
-  exportSettings: ExportSettings
+  exportSettings: ExportSettings,
+  renderAtScale: RenderAtScale
 ): ExportHooks {
   const { scale, quality, compress } = exportSettings
 
@@ -57,12 +68,20 @@ export function useExport(
     [character, text, customImage]
   )
 
-  /** Preview canvas stays 296×256; export uses content bounds + scale. */
+  /**
+   * Hi-DPI path: re-draw at scale then crop transparent padding.
+   * 1× still re-draws via renderAtScale so crop is consistent;
+   * falls back to preview canvas if render fails.
+   */
   const getExportCanvas = useCallback((): HTMLCanvasElement | null => {
+    const rendered = renderAtScale(scale)
+    if (rendered) {
+      return cropCanvasToContent(rendered)
+    }
     const canvas = canvasRef.current
     if (!canvas) return null
-    return prepareExportCanvas(canvas, scale)
-  }, [canvasRef, scale])
+    return cropCanvasToContent(canvas)
+  }, [canvasRef, scale, renderAtScale])
 
   const lossyQuality = compress ? Math.min(1, Math.max(0.1, quality)) : 1
 

--- a/src/utils/cropCanvas.ts
+++ b/src/utils/cropCanvas.ts
@@ -108,33 +108,3 @@ export function canvasWithWhiteBackground(source: HTMLCanvasElement): HTMLCanvas
   return out
 }
 
-/**
- * Scale a canvas by an integer/float factor using high-quality smoothing.
- * scale <= 1 returns the same canvas reference (no copy) for the common 1x path.
- */
-export function scaleCanvas(source: HTMLCanvasElement, scale: number): HTMLCanvasElement {
-  if (!Number.isFinite(scale) || scale <= 0 || scale === 1) {
-    return source
-  }
-
-  const out = document.createElement('canvas')
-  out.width = Math.max(1, Math.round(source.width * scale))
-  out.height = Math.max(1, Math.round(source.height * scale))
-  const ctx = out.getContext('2d')
-  if (ctx) {
-    ctx.imageSmoothingEnabled = true
-    ctx.imageSmoothingQuality = 'high'
-    ctx.drawImage(source, 0, 0, out.width, out.height)
-  }
-  return out
-}
-
-/**
- * Crop transparent padding then optionally scale for export.
- */
-export function prepareExportCanvas(
-  source: HTMLCanvasElement,
-  scale: number = 1
-): HTMLCanvasElement {
-  return scaleCanvas(cropCanvasToContent(source), scale)
-}


### PR DESCRIPTION
## 问题
#8 实现里的「导出尺寸 2×/3×」是把预览位图 `drawImage` 放大，**文字/描边也会糊**——等于放大糊图。

## 修复
- `useCanvasDrawing.draw(..., scale)`：按倍率放大画布，并同步放大字号、描边、坐标、字距后**重新绘制**
- 导出 / 上传走离屏 `renderAtScale` → 裁透明边，不再 bitmap upscale
- 角色底图仍用完整源像素绘制，但**无法凭空增加底图细节**（#3 限制仍在）
- UI 文案改为：按倍率重新绘制（文字清晰）；底图受素材限制

## Test plan
- [ ] 2× / 3× 导出 PNG：文字边缘明显比改前锐利
- [ ] 布局与 1× 预览比例一致（位置/竖排间距）
- [ ] 1× 行为不变
- [ ] JPG/WEBP 质量滑块仍生效
- [ ] 上传分享尊重倍率并走重绘路径

Refs #7