### PR TITLE
feat: 认证改用 sekai-auth SDK（含旧存储迁移）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,9 @@ jobs:
         run: npm ci || npm install
       - name: Build
         run: npm run build
+      - name: Typecheck
+        run: npm run type-check
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sekai-stickers-merged",
       "version": "1.0.0",
       "dependencies": {
+        "@25-ji-code-de/sekai-auth": "github:25-ji-code-de/sekai-auth#v0.1.2",
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.15.0",
@@ -34,6 +35,14 @@
         "vite": "^7.3.0",
         "vite-plugin-pwa": "^1.2.0",
         "workbox-window": "^7.4.0"
+      }
+    },
+    "node_modules/@25-ji-code-de/sekai-auth": {
+      "version": "0.1.2",
+      "resolved": "git+ssh://git@github.com/25-ji-code-de/sekai-auth.git#65bc8eb66f23b35b6f8d6a2ffd9464f8c5a46680",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,17 @@
   "private": true,
   "version": "1.0.0",
   "type": "module",
+  "description": "SEKAI 贴纸生成器",
+  "license": "AGPL-3.0-only",
+  "author": "The 25-ji-code-de Team",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/25-ji-code-de/stickers-maker.git"
+  },
+  "homepage": "https://github.com/25-ji-code-de/stickers-maker#readme",
+  "bugs": {
+    "url": "https://github.com/25-ji-code-de/stickers-maker/issues"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "build": "vite build",
     "lint": "eslint . --ext js,jsx,ts,tsx --report-unused-disable-directives",
     "type-check": "tsc --noEmit",
+    "test": "node --test \"test/*.test.mjs\"",
     "preview": "vite preview",
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@25-ji-code-de/sekai-auth": "github:25-ji-code-de/sekai-auth#v0.1.2",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.15.0",

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -2,295 +2,185 @@
 // Copyright (C) 2026 The 25-ji-code-de Team
 
 /**
- * OAuth 2.1 + OIDC Authentication Service
+ * OAuth 2.1 + OIDC 认证服务 —— 实现已移至 @25-ji-code-de/sekai-auth（Apache-2.0）。
  *
- * Aligned with hub / 25ji client conventions:
- * - sessionStorage for PKCE (via storage.service)
- * - single-flight refresh
- * - refresh 5 minutes before expiry
+ * 这个文件此前是生态内四份独立 OAuth 实现之一（另外三份在 hub、25ji-sagyo、
+ * nightcord）。现在只做三件事：
+ *   1. 把 Vite 的 import.meta.env 映射成 SDK 的构造参数
+ *   2. 把 SDK 的离散 storage key 与本仓历史上的单块 JSON blob 做一次性迁移
+ *   3. 保留 AuthState 形状与既有导出签名，useAuth / AuthCallback 无需改动
  */
 
-import { AuthUser, AuthState, TokenResponse, OIDCUserInfo } from '../types'
-import { generateCodeVerifier, generateCodeChallenge, generateState } from '../utils/crypto.utils'
-import {
-  saveAuthState,
-  loadAuthState,
-  clearAuthState,
-  savePKCEVerifier,
-  consumePKCEVerifier,
-  saveOAuthState,
-  consumeOAuthState,
-} from './storage.service'
-import {
-  getAuthorizationEndpoint,
-  getTokenEndpoint,
-  getUserInfoEndpoint,
-} from './oidc.service'
+import { SekaiAuth, SekaiAuthError } from '@25-ji-code-de/sekai-auth'
+import { AuthUser, AuthState, OIDCUserInfo } from '../types'
 
 const CLIENT_ID = import.meta.env.VITE_OAUTH_CLIENT_ID || ''
 const REDIRECT_URI = import.meta.env.VITE_OAUTH_REDIRECT_URI || `${window.location.origin}/callback`
 const SCOPE = import.meta.env.VITE_OAUTH_SCOPE || 'openid profile email'
+const ISSUER = import.meta.env.VITE_OAUTH_ISSUER || 'https://id.nightcord.de5.net'
 
-/** Coalesce concurrent refreshAccessToken / getCurrentAuth refresh paths */
-let refreshPromise: Promise<AuthState> | null = null
+/** 迁移前把整包 AuthState 存成 JSON 的那个 key。 */
+const LEGACY_BLOB_KEY = 'ayaka_auth_state'
+
+const auth = new SekaiAuth({
+  clientId: CLIENT_ID,
+  redirectUri: REDIRECT_URI,
+  scope: SCOPE,
+  // 本仓是生态里唯一走 OIDC discovery 的（其余三个硬编码端点）
+  issuer: ISSUER,
+  storagePrefix: 'ayaka_',
+  keys: {
+    // 沿用迁移前的 PKCE key 名，避免部署瞬间正在跳转的登录流程失败
+    codeVerifier: 'ayaka_pkce_verifier',
+    state: 'ayaka_oauth_state',
+  },
+})
 
 /**
- * Start OAuth login flow
- * Redirects to authorization endpoint with PKCE parameters
+ * 一次性迁移：把旧的单块 JSON blob 拆成 SDK 的离散 key。
+ *
+ * 不做这一步的话，上线瞬间所有已登录用户都会被登出。
+ * 迁移后删掉 blob，因此只会执行一次。
+ */
+function migrateLegacyBlob(): void {
+  let raw: string | null
+  try {
+    raw = localStorage.getItem(LEGACY_BLOB_KEY)
+  } catch {
+    return
+  }
+  if (!raw) return
+
+  try {
+    const legacy = JSON.parse(raw) as Partial<AuthState>
+    if (legacy.accessToken && legacy.expiresAt) {
+      localStorage.setItem(auth.keys.accessToken, legacy.accessToken)
+      localStorage.setItem(auth.keys.expiresAt, String(legacy.expiresAt))
+      if (legacy.refreshToken) {
+        localStorage.setItem(auth.keys.refreshToken, legacy.refreshToken)
+      }
+      if (legacy.user) {
+        // 旧 blob 存的是映射后的 AuthUser；这里回填成 userinfo 形状供缓存读取
+        localStorage.setItem(
+          auth.keys.user,
+          JSON.stringify({
+            sub: legacy.user.id,
+            preferred_username: legacy.user.username,
+            email: legacy.user.email ?? undefined,
+            picture: legacy.user.avatar ?? undefined,
+          }),
+        )
+      }
+    }
+  } catch {
+    /* blob 损坏就当作未登录 */
+  }
+
+  try {
+    localStorage.removeItem(LEGACY_BLOB_KEY)
+  } catch {
+    /* ignore */
+  }
+}
+
+migrateLegacyBlob()
+
+/** 把 OIDC userinfo 映射成本仓的 AuthUser。 */
+function toAuthUser(userInfo: OIDCUserInfo): AuthUser {
+  return {
+    id: userInfo.sub,
+    username: userInfo.preferred_username || userInfo.name || userInfo.sub,
+    email: userInfo.email || null,
+    avatar: userInfo.picture || null,
+  }
+}
+
+/** 从 SDK 的离散存储还原出本仓的 AuthState 形状。 */
+function readAuthState(user: AuthUser): AuthState {
+  return {
+    accessToken: localStorage.getItem(auth.keys.accessToken) ?? '',
+    refreshToken: localStorage.getItem(auth.keys.refreshToken) ?? undefined,
+    idToken: undefined,
+    expiresAt: Number(localStorage.getItem(auth.keys.expiresAt) ?? 0),
+    user,
+  }
+}
+
+/** 取 userinfo 并映射；失败时抛出统一异常。 */
+async function requireUser(): Promise<AuthUser> {
+  const userInfo = await auth.getUserInfo({ cache: true })
+  if (!userInfo) {
+    throw new SekaiAuthError('Failed to fetch user info', { code: 'userinfo_failed' })
+  }
+  return toAuthUser(userInfo as unknown as OIDCUserInfo)
+}
+
+/**
+ * 发起登录，跳转到授权端点（带 PKCE 参数）。
  */
 export async function initiateLogin(): Promise<void> {
   try {
-    // Generate PKCE parameters
-    const codeVerifier = generateCodeVerifier()
-    const codeChallenge = await generateCodeChallenge(codeVerifier)
-    const state = generateState()
-
-    // Store for later verification
-    savePKCEVerifier(codeVerifier)
-    saveOAuthState(state)
-
-    // Build authorization URL
-    const authEndpoint = await getAuthorizationEndpoint()
-    const params = new URLSearchParams({
-      client_id: CLIENT_ID,
-      redirect_uri: REDIRECT_URI,
-      response_type: 'code',
-      scope: SCOPE,
-      state: state,
-      code_challenge: codeChallenge,
-      code_challenge_method: 'S256',
-    })
-
-    // Redirect to authorization endpoint
-    window.location.href = `${authEndpoint}?${params.toString()}`
+    await auth.login()
   } catch (err) {
-    throw new Error(`Failed to initiate login: ${err instanceof Error ? err.message : 'Unknown error'}`)
+    throw new Error(
+      `Failed to initiate login: ${err instanceof Error ? err.message : 'Unknown error'}`,
+    )
   }
 }
 
 /**
- * Handle OAuth callback
- * Exchanges authorization code for tokens
- * @param code - Authorization code from callback URL
- * @param state - State parameter from callback URL
- * @returns Auth state with user info
- * @throws Error if exchange fails or state mismatch
+ * 处理 OAuth 回调，用 code 换 token。
+ * @throws 换取失败或 state 不匹配时抛出
  */
 export async function handleCallback(code: string, state: string): Promise<AuthState> {
   try {
-    // Verify state parameter (CSRF protection)
-    const expectedState = consumeOAuthState()
-    if (!expectedState || expectedState !== state) {
-      throw new Error('Invalid state parameter - possible CSRF attack')
-    }
-
-    // Get code verifier
-    const codeVerifier = consumePKCEVerifier()
-    if (!codeVerifier) {
-      throw new Error('Missing PKCE code verifier')
-    }
-
-    // Exchange code for tokens
-    const tokenEndpoint = await getTokenEndpoint()
-    const tokenResponse = await fetch(tokenEndpoint, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: new URLSearchParams({
-        grant_type: 'authorization_code',
-        code: code,
-        redirect_uri: REDIRECT_URI,
-        client_id: CLIENT_ID,
-        code_verifier: codeVerifier,
-      }),
-    })
-
-    if (!tokenResponse.ok) {
-      const error = await tokenResponse.text()
-      throw new Error(`Token exchange failed: ${error}`)
-    }
-
-    const tokens: TokenResponse = await tokenResponse.json()
-
-    // Get user info
-    const user = await fetchUserInfo(tokens.access_token)
-
-    // Calculate expiration time
-    const expiresIn = Number(tokens.expires_in) || 3600
-    const expiresAt = Date.now() + expiresIn * 1000
-
-    // Create and save auth state
-    const authState: AuthState = {
-      accessToken: tokens.access_token,
-      refreshToken: tokens.refresh_token,
-      idToken: tokens.id_token,
-      expiresAt: expiresAt,
-      user: user,
-    }
-
-    saveAuthState(authState)
-
-    return authState
+    await auth.handleCallback(code, state)
+    return readAuthState(await requireUser())
   } catch (err) {
-    throw new Error(`Callback handling failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
+    throw new Error(
+      `Callback handling failed: ${err instanceof Error ? err.message : 'Unknown error'}`,
+    )
   }
 }
 
 /**
- * Fetch user info from userinfo endpoint
- * @param accessToken - Access token
- * @returns User information
+ * 用 refresh token 换新的 access token（single-flight，由 SDK 保证）。
+ *
+ * 参数保留是为了兼容既有签名 —— SDK 从存储里读 refresh token，不需要传入。
+ * @throws 刷新失败时抛出，并清空本地状态
  */
-async function fetchUserInfo(accessToken: string): Promise<AuthUser> {
-  try {
-    const userinfoEndpoint = await getUserInfoEndpoint()
-    const response = await fetch(userinfoEndpoint, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    })
-
-    if (!response.ok) {
-      throw new Error(`Failed to fetch user info: ${response.statusText}`)
-    }
-
-    const userInfo: OIDCUserInfo = await response.json()
-
-    // Map OIDC user info to AuthUser
-    return {
-      id: userInfo.sub,
-      username: userInfo.preferred_username || userInfo.name || userInfo.sub,
-      email: userInfo.email || null,
-      avatar: userInfo.picture || null,
-    }
-  } catch (err) {
-    throw new Error(`User info fetch failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
+export async function refreshAccessToken(_refreshToken?: string): Promise<AuthState> {
+  const token = await auth.refresh()
+  if (!token) {
+    throw new Error('Token refresh failed')
   }
+  return readAuthState(await requireUser())
 }
 
 /**
- * Refresh access token using refresh token (single-flight)
- * @param refreshToken - Refresh token
- * @returns New auth state
- * @throws Error if refresh fails
- */
-export async function refreshAccessToken(refreshToken: string): Promise<AuthState> {
-  if (refreshPromise) {
-    return refreshPromise
-  }
-  refreshPromise = doRefreshAccessToken(refreshToken).finally(() => {
-    refreshPromise = null
-  })
-  return refreshPromise
-}
-
-async function doRefreshAccessToken(refreshToken: string): Promise<AuthState> {
-  try {
-    const tokenEndpoint = await getTokenEndpoint()
-    const response = await fetch(tokenEndpoint, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: new URLSearchParams({
-        grant_type: 'refresh_token',
-        refresh_token: refreshToken,
-        client_id: CLIENT_ID,
-      }),
-    })
-
-    if (!response.ok) {
-      throw new Error(`Token refresh failed: ${response.statusText}`)
-    }
-
-    const tokens: TokenResponse = await response.json()
-
-    // Get updated user info
-    const user = await fetchUserInfo(tokens.access_token)
-
-    // Calculate new expiration time
-    const expiresIn = Number(tokens.expires_in) || 3600
-    const expiresAt = Date.now() + expiresIn * 1000
-
-    // Create and save new auth state
-    const authState: AuthState = {
-      accessToken: tokens.access_token,
-      refreshToken: tokens.refresh_token || refreshToken, // Keep old refresh token if not provided
-      idToken: tokens.id_token,
-      expiresAt: expiresAt,
-      user: user,
-    }
-
-    saveAuthState(authState)
-
-    return authState
-  } catch (err) {
-    // Clear auth state on refresh failure
-    clearAuthState()
-    throw new Error(`Token refresh failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
-  }
-}
-
-/**
- * Logout and clear auth state (best-effort server revoke)
+ * 登出：best-effort 撤销服务端 token，再清空本地。
  */
 export function logout(): void {
-  const authState = loadAuthState()
-  if (authState) {
-    const revoke = async (token: string | undefined, hint: string) => {
-      if (!token) return
-      try {
-        const tokenEndpoint = await getTokenEndpoint()
-        const revokeUrl = tokenEndpoint.replace(/\/token$/, '/revoke')
-        void fetch(revokeUrl, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: new URLSearchParams({
-            token,
-            token_type_hint: hint,
-            client_id: CLIENT_ID,
-          }),
-          keepalive: true,
-        }).catch(() => {})
-      } catch {
-        /* ignore */
-      }
-    }
-    void revoke(authState.refreshToken, 'refresh_token')
-    void revoke(authState.accessToken, 'access_token')
-  }
-  clearAuthState()
+  void auth.logout()
 }
 
 /**
- * Get current auth state
- * Automatically refreshes if expired/expiring soon and refresh token is available
- * @returns Current auth state or null if not authenticated
+ * 取当前认证状态。过期或即将过期（5 分钟内）时自动刷新。
+ * @returns 未登录、或刷新失败时返回 null
  */
 export async function getCurrentAuth(): Promise<AuthState | null> {
-  const authState = loadAuthState()
+  // getAccessToken 内部已经处理了「快过期就提前刷新」和刷新失败清状态
+  const token = await auth.getAccessToken()
+  if (!token) return null
 
-  if (!authState) {
-    return null
-  }
+  const cached = auth.getCachedUser()
+  const user = cached
+    ? toAuthUser(cached as unknown as OIDCUserInfo)
+    : await requireUser().catch(() => null)
+  if (!user) return null
 
-  // Refresh if expired or within 5 minutes of expiry (ecosystem convention)
-  const needsRefresh = Date.now() >= authState.expiresAt - 5 * 60 * 1000
-
-  if (needsRefresh && authState.refreshToken) {
-    try {
-      return await refreshAccessToken(authState.refreshToken)
-    } catch {
-      clearAuthState()
-      return null
-    }
-  }
-
-  if (needsRefresh) {
-    clearAuthState()
-    return null
-  }
-
-  return authState
+  return readAuthState(user)
 }
+
+/** 底层 SDK 实例，供需要新能力时直接使用。 */
+export { auth as sekaiAuth }

--- a/test/legacy-migration.test.mjs
+++ b/test/legacy-migration.test.mjs
@@ -1,0 +1,200 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (C) 2026 The 25-ji-code-de Team
+ *
+ * stickers-maker 迁移垫片的测试。
+ *
+ * 本仓是四个前端里唯一把整包 AuthState 存成单个 JSON blob 的
+ * （其余三个用离散 key）。迁移到 SDK 的离散存储时如果不做转换，
+ * 上线瞬间所有已登录用户都会被登出。
+ *
+ * auth.service.ts 是 TS + 依赖 import.meta.env，没法直接在 node 里 import，
+ * 所以这里把迁移逻辑按同样的规则重现一遍并测它 —— 两边必须保持同步。
+ */
+
+import { test, describe, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { SekaiAuth } from '@25-ji-code-de/sekai-auth';
+
+class MemoryStorage {
+  constructor() {
+    this.map = new Map();
+  }
+  getItem(k) {
+    return this.map.has(k) ? this.map.get(k) : null;
+  }
+  setItem(k, v) {
+    this.map.set(k, String(v));
+  }
+  removeItem(k) {
+    this.map.delete(k);
+  }
+  clear() {
+    this.map.clear();
+  }
+}
+
+const local = new MemoryStorage();
+const session = new MemoryStorage();
+const LEGACY_BLOB_KEY = 'ayaka_auth_state';
+
+function makeAuth() {
+  return new SekaiAuth({
+    clientId: 'maker_client',
+    redirectUri: 'https://st.example/callback',
+    endpoints: {
+      authorize: 'https://id.example/oauth/authorize',
+      token: 'https://id.example/oauth/token',
+      userinfo: 'https://id.example/oauth/userinfo',
+    },
+    storagePrefix: 'ayaka_',
+    keys: {
+      codeVerifier: 'ayaka_pkce_verifier',
+      state: 'ayaka_oauth_state',
+    },
+    localStorage: local,
+    sessionStorage: session,
+  });
+}
+
+/** 与 src/services/auth.service.ts 的 migrateLegacyBlob 保持一致。 */
+function migrateLegacyBlob(auth) {
+  const raw = local.getItem(LEGACY_BLOB_KEY);
+  if (!raw) return;
+
+  try {
+    const legacy = JSON.parse(raw);
+    if (legacy.accessToken && legacy.expiresAt) {
+      local.setItem(auth.keys.accessToken, legacy.accessToken);
+      local.setItem(auth.keys.expiresAt, String(legacy.expiresAt));
+      if (legacy.refreshToken) {
+        local.setItem(auth.keys.refreshToken, legacy.refreshToken);
+      }
+      if (legacy.user) {
+        local.setItem(
+          auth.keys.user,
+          JSON.stringify({
+            sub: legacy.user.id,
+            preferred_username: legacy.user.username,
+            email: legacy.user.email ?? undefined,
+            picture: legacy.user.avatar ?? undefined,
+          }),
+        );
+      }
+    }
+  } catch {
+    /* 损坏就当未登录 */
+  }
+
+  local.removeItem(LEGACY_BLOB_KEY);
+}
+
+let auth;
+beforeEach(() => {
+  local.clear();
+  session.clear();
+  auth = makeAuth();
+});
+
+describe('storage key', () => {
+  test('沿用 ayaka_ 前缀，PKCE key 与迁移前一致', () => {
+    assert.equal(auth.keys.accessToken, 'ayaka_access_token');
+    assert.equal(auth.keys.refreshToken, 'ayaka_refresh_token');
+    assert.equal(auth.keys.expiresAt, 'ayaka_expires_at');
+    assert.equal(auth.keys.user, 'ayaka_user');
+    // 这两个是显式覆盖的，保证部署瞬间正在跳转的登录流程不会失败
+    assert.equal(auth.keys.codeVerifier, 'ayaka_pkce_verifier');
+    assert.equal(auth.keys.state, 'ayaka_oauth_state');
+  });
+});
+
+describe('旧 blob 迁移', () => {
+  const expiresAt = Date.now() + 60 * 60 * 1000;
+
+  test('完整 blob 拆成离散 key，且不会登出用户', () => {
+    local.setItem(
+      LEGACY_BLOB_KEY,
+      JSON.stringify({
+        accessToken: 'AT',
+        refreshToken: 'RT',
+        expiresAt,
+        user: { id: 'u1', username: 'ayaka', email: 'a@example.com', avatar: 'https://c/a.png' },
+      }),
+    );
+
+    migrateLegacyBlob(auth);
+
+    assert.equal(local.getItem('ayaka_access_token'), 'AT');
+    assert.equal(local.getItem('ayaka_refresh_token'), 'RT');
+    assert.equal(local.getItem('ayaka_expires_at'), String(expiresAt));
+    assert.equal(auth.isAuthenticated(), true, '迁移后必须仍视为已登录');
+  });
+
+  test('user 被回填成 userinfo 形状供缓存读取', () => {
+    local.setItem(
+      LEGACY_BLOB_KEY,
+      JSON.stringify({
+        accessToken: 'AT',
+        expiresAt,
+        user: { id: 'u1', username: 'ayaka', email: 'a@example.com', avatar: 'https://c/a.png' },
+      }),
+    );
+
+    migrateLegacyBlob(auth);
+
+    assert.deepEqual(auth.getCachedUser(), {
+      sub: 'u1',
+      preferred_username: 'ayaka',
+      email: 'a@example.com',
+      picture: 'https://c/a.png',
+    });
+  });
+
+  test('迁移后删除 blob —— 只执行一次', () => {
+    local.setItem(LEGACY_BLOB_KEY, JSON.stringify({ accessToken: 'AT', expiresAt }));
+    migrateLegacyBlob(auth);
+    assert.equal(local.getItem(LEGACY_BLOB_KEY), null);
+
+    // 第二次运行不应改变任何东西
+    local.setItem('ayaka_access_token', 'NEWER');
+    migrateLegacyBlob(auth);
+    assert.equal(local.getItem('ayaka_access_token'), 'NEWER');
+  });
+
+  test('没有 refresh token 的 blob 也能迁移', () => {
+    local.setItem(LEGACY_BLOB_KEY, JSON.stringify({ accessToken: 'AT', expiresAt }));
+    migrateLegacyBlob(auth);
+    assert.equal(local.getItem('ayaka_access_token'), 'AT');
+    assert.equal(local.getItem('ayaka_refresh_token'), null);
+    assert.equal(auth.isAuthenticated(), true);
+  });
+
+  test('blob 损坏时不抛异常，且照样清掉', () => {
+    local.setItem(LEGACY_BLOB_KEY, '{not json');
+    assert.doesNotThrow(() => migrateLegacyBlob(auth));
+    assert.equal(local.getItem(LEGACY_BLOB_KEY), null);
+    assert.equal(auth.isAuthenticated(), false);
+  });
+
+  test('缺 accessToken 的 blob 不写入任何东西', () => {
+    local.setItem(LEGACY_BLOB_KEY, JSON.stringify({ refreshToken: 'RT', expiresAt }));
+    migrateLegacyBlob(auth);
+    assert.equal(local.getItem('ayaka_access_token'), null);
+    assert.equal(auth.isAuthenticated(), false);
+  });
+
+  test('没有旧 blob 时是无操作', () => {
+    assert.doesNotThrow(() => migrateLegacyBlob(auth));
+    assert.equal(auth.isAuthenticated(), false);
+  });
+
+  test('已过期的 blob 迁移后仍算已登录（有 refresh token 可续期）', () => {
+    local.setItem(
+      LEGACY_BLOB_KEY,
+      JSON.stringify({ accessToken: 'AT', refreshToken: 'RT', expiresAt: Date.now() - 1 }),
+    );
+    migrateLegacyBlob(auth);
+    assert.equal(auth.isAuthenticated(), true);
+  });
+});


### PR DESCRIPTION
四份独立 OAuth 实现的**最后一份**。配套 [hub#1](https://github.com/25-ji-code-de/hub/pull/1)、[25ji-sagyo#9](https://github.com/25-ji-code-de/25ji-sagyo/pull/9)、[nightcord#1](https://github.com/25-ji-code-de/nightcord/pull/1)。

本仓有 Vite 构建步骤，所以走 **git dependency**（`github:25-ji-code-de/sekai-auth#v0.1.2`）而不是像那三个静态站那样内联。

## 这个 PR 最需要审的地方：存储迁移

本仓是四个前端里**唯一**把整包 `AuthState` 存成单个 JSON blob 的：

    localStorage['ayaka_auth_state'] = '{"accessToken":...,"refreshToken":...,"user":{...}}'

其余三个都用离散 key。直接切到 SDK 的离散存储 = **上线瞬间所有已登录用户被登出**。

所以加了一次性迁移垫片，在模块加载时执行：

    ayaka_auth_state (blob)  →  ayaka_access_token
                                 ayaka_refresh_token
                                 ayaka_expires_at
                                 ayaka_user
    然后删掉 blob（因此只会跑一次）

`user` 字段要做形状转换 —— 旧 blob 存的是映射后的 `AuthUser`（`{id, username, email, avatar}`），SDK 的缓存读的是 userinfo 形状（`{sub, preferred_username, ...}`）。

PKCE 的两个 key 名也**显式沿用旧值**（`ayaka_pkce_verifier` / `ayaka_oauth_state`，而不是 SDK 默认的 `ayaka_code_verifier` / `ayaka_state`），这样部署那一瞬间正在跳转授权页的用户回来后还能换到 token。

有 9 个测试专门覆盖这个垫片：完整 blob、无 refresh token、blob 损坏、缺 accessToken、重复执行、已过期但有 refresh token。

## 保留的东西

- 导出签名不变，`useAuth` 和 `AuthCallback` **一行没改**
- 本仓是生态里唯一走 **OIDC discovery** 的，这个特性保留（SDK 支持 `issuer`）
- `refreshAccessToken(refreshToken)` 的参数保留但不再使用 —— SDK 从存储里读

## CI

此前 CI **只跑 `build`** —— 装了 typescript 却没有 type-check 入口，lint 又因为 `--ext js,jsx` 而从未检查过任何 `.ts`/`.tsx`（那个已在上一个提交修掉）。这里把 `type-check` / `lint` / `test` 都加进去。

本地 `tsc --noEmit` 0 错误、`eslint` 0 错误 3 警告（都是既有的 exhaustive-deps）、`vite build` 通过。

> 我没有直接推 main：这改的是生产站点的登录链路和本地存储格式，我无法在真实浏览器里验证迁移。